### PR TITLE
(4-3)初級 パンくずリスト修正

### DIFF
--- a/src/views/EmployeeDetail.vue
+++ b/src/views/EmployeeDetail.vue
@@ -4,7 +4,9 @@
     <nav>
       <div class="nav-wrapper">
         <div class="col s12 teal">
-          <a class="breadcrumb">従業員リスト</a>
+          <router-link to="/employeeList" class="breadcrumb"
+            >従業員リスト</router-link
+          >
           <a class="breadcrumb">従業員詳細</a>
         </div>
       </div>


### PR DESCRIPTION
従業員詳細から従業員一覧に戻るパンくずリストのリンクが切れているのを修正しました。
レビューをお願い致します。